### PR TITLE
feat: better error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 var argv = require('minimist')(process.argv.slice(2));
 var path = require('path');
+var gutil = require('gulp-util');
 
 function loadTask (gulp, taskName, taskPath) {
   try {
     var taskFunc = require(taskPath);
   } catch (e) {
-    throw new Error ('could not load task "' + taskName + '"');
+    gutil.log('could not load task "' + taskName + '"');
+    throw e;
   }
 
   if (taskFunc.private) {
@@ -21,7 +23,8 @@ function loadTask (gulp, taskName, taskPath) {
     try {
       loadTask(gulp, depPath, depRealPath);
     } catch (e) {
-      throw new Error('could not load task dependency "' + depPath + '" for "' + taskName + '"');
+      gutil.log('could not load task dependency "' + depPath + '" for "' + taskName + '"');
+      throw e;
     }
   });
 
@@ -43,11 +46,7 @@ module.exports = function (options) {
   tasks.forEach(function (taskName) {
     bases.forEach(function (basePath) {
       var taskPath = path.join(process.cwd(), basePath, taskName);
-      try {
-        loadTask(gulp, taskName, taskPath);
-      } catch (e) {
-        throw e;
-      }
+      loadTask(gulp, taskName, taskPath);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "glob": "^4.4.1",
+    "gulp-util": "^3.0.7",
     "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
not rethrowing the original error hides the actual problem (e.g. whether there is a SyntaxError, or some dependency not resolved, etc.)
Even `--verbose` can't find these problems, so use `gulp-util` to log a friendly message, but rethrow original error.
